### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/ssrfDicts/deal_log.py
+++ b/ssrfDicts/deal_log.py
@@ -4,7 +4,7 @@ def ddddd(dic):
         o = f.readlines()
     print len(o)
     o = sorted(list(set(o)))
-    print len(o)
+    print(len(o))
     # with open(dic, 'w') as f:
     #     for i in o:
     #         f.write(i)


### PR DESCRIPTION
Legacy __print__ statements are _syntax errors_ in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.